### PR TITLE
Prevent future spam leaderboard changes

### DIFF
--- a/commands/leaderboard.py
+++ b/commands/leaderboard.py
@@ -13,8 +13,8 @@ SLEEP_INTERVAL = 60
 
 async def leaderboard(client, channel):
     req = urllib.request.Request(
-        MEE6_URL + channel.server.id, 
-        data=None, 
+        MEE6_URL + channel.server.id,
+        data=None,
         headers={
             'User-Agent': SPOOF_AGENT
         }
@@ -59,10 +59,15 @@ async def leaderboard(client, channel):
                         alerts.append("{} has just entered the top 100.".format(at(user)))
         except FileNotFoundError:
             pass
-        
+
         # Save new data
         with open(DATA_FILE, 'w') as new:
             json.dump(new_positions, new)
+
+        # Prevent PR disaster
+        if len(alerts) > 10:
+            print(timestamp() + ' LEADERBOARD: more than 10 changes to the leaderboard')
+            continue
 
         # Output any alerts
         for alert in alerts:


### PR DESCRIPTION
So you know, that doesn't happen again. It's reasonable to say no more than 10 leaderboard changes will occur within a minute right? Guess it doesn't really matter if it misses one.

Sorry about the whitespace changes, those were automatically done by my editor.