### PR TITLE
Hushed the "water" command if you're not in a voice channel

### DIFF
--- a/commands/base.py
+++ b/commands/base.py
@@ -112,16 +112,16 @@ class Command(metaclass=Tree):
                                      " or ".join([chan(x.id) for x in cr]))
 
 
-    async def play_mp3(self, file):
+    async def play_mp3(self, file, quiet=False):
         global player
 
         channel = self.message.author.voice.voice_channel
 
         if not channel:
-            raise CommandFailure("You need to join a voice channel to use this command")
+            raise CommandFailure("You need to join a voice channel to use this command") if not quiet else return
 
         if player:
-            raise CommandFailure("Already playing something!")
+            raise CommandFailure("Already playing something!") if not quiet else return
 
         # Check if bot is connected already in the server
         vclients = list(self.client.voice_clients)

--- a/commands/base.py
+++ b/commands/base.py
@@ -118,10 +118,16 @@ class Command(metaclass=Tree):
         channel = self.message.author.voice.voice_channel
 
         if not channel:
-            raise CommandFailure("You need to join a voice channel to use this command") if not quiet else return
+            if not quiet:
+                raise CommandFailure("You need to join a voice channel to use this command")
+            else:
+                return
 
         if player:
-            raise CommandFailure("Already playing something!") if not quiet else return
+            if not quiet:
+                raise CommandFailure("Already playing something!")
+            else:
+                return
 
         # Check if bot is connected already in the server
         vclients = list(self.client.voice_clients)

--- a/commands/sounds.py
+++ b/commands/sounds.py
@@ -34,5 +34,5 @@ class Water(S):
     #roles_required = ['mod', 'exec']
     async def eval(self):
         await self.client.send_message(self.message.channel, "https://i.imgur.com/vQ0JLpa.png")
-        await self.play_mp3('water.mp3')
+        await self.play_mp3('water.mp3', quiet=True)
         return 


### PR DESCRIPTION
Added the ability to suppress the warnings for the `play_mp3` function used by "water" and "high noon". I enabled this for the water command because people would use the command outside of voice channels, pestering them with an error. The ability to raise an error is still retained by high noon, and easily changeable later. Since both commands play short sound clips, I don't think they would overlap easily, so I don't imagine these errors being raised usually otherwise.