### PR TITLE
Birthday feature

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@
 #from commands.highnoon import high_noon, HIGH_NOON_CHANNEL
 #from commands.leaderboard import leaderboard, LEADERBOARD_CHANNEL
 from commands.twitch import twitch, TWITCH_CHANNEL
+from commands.birthday import update_birthday
 
 import json
 import os
@@ -20,7 +21,6 @@ high_noon_channel = None
 DEFAULT_PRESENCE = "!helpme"
 err = """OOPSIE WOOPSIE!! Uwu We made a fucky wucky!! A wittle fucko boingo!
 The code monkeys at our headquarters are working VEWY HAWD to fix this!"""
-
 
 @client.event
 async def on_ready():
@@ -44,6 +44,10 @@ async def on_ready():
     print('------')
 
     await client.change_presence(game=discord.Game(name=presence))
+
+    # Birthday checking!
+    asyncio.ensure_future(update_birthday())
+
     for channel in client.get_all_channels():
 
         # if channel.name == HIGH_NOON_CHANNEL:

--- a/bot.py
+++ b/bot.py
@@ -46,7 +46,8 @@ async def on_ready():
     await client.change_presence(game=discord.Game(name=presence))
 
     # Birthday checking!
-    asyncio.ensure_future(update_birthday())
+    #print(client.servers[0])
+    asyncio.ensure_future(update_birthday(client))
 
     for channel in client.get_all_channels():
 

--- a/bot.py
+++ b/bot.py
@@ -46,7 +46,6 @@ async def on_ready():
     await client.change_presence(game=discord.Game(name=presence))
 
     # Birthday checking!
-    #print(client.servers[0])
     asyncio.ensure_future(update_birthday(client))
 
     for channel in client.get_all_channels():

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,4 +1,5 @@
 from configstartup import config
+from commands.birthday import *
 from commands.base import *
 from commands.help import *
 from commands.pingpong import *

--- a/commands/birthday.py
+++ b/commands/birthday.py
@@ -92,7 +92,6 @@ def find_user(birthdays, user):
     Returns the day_month string if their birthday has been stored.
     Returns None if they haven't inputted their birthday.
     """
-    # use for ... checking if they've already added and for removing
     for date, users in birthdays.items():
         if user in users:
             return date

--- a/commands/birthday.py
+++ b/commands/birthday.py
@@ -2,13 +2,16 @@ import asyncio
 from collections import defaultdict
 import datetime
 import json
-import re
+
+from discord.utils import find
 
 from commands.base import Command
 from helpers import CommandFailure
 
+
 BIRTHDAY_FILE = "files/birthdays.json"
-BIRTHDAY_ROLE_NAME = "Birthday!"
+BDAY_ROLE_NAME = "Birthday!"
+
 
 class Birthday(Command):
     desc = "This command can be used to add or remove your birthday. When it is " \
@@ -61,7 +64,6 @@ class Remove(Birthday):
         return "Your birthday has been removed."
 
 
-
 def get_birthdays(bday_file):
     """
     Gets JSON object of all birthdays
@@ -111,21 +113,21 @@ async def update_birthday(client):
             # It's a new day - remove all previous roles, add new roles
             all_birthdays = get_birthdays(BIRTHDAY_FILE)
             dm_today = new.strftime("%d/%m")
-            
+
             # Get all members
             server = list(client.servers)[0]
             members = server.members
-            birthday_role = next(x for x in server.roles if x.name == BIRTHDAY_ROLE_NAME)
+            bday_role = find(lambda r: r.name == BDAY_ROLE_NAME, server.roles)
 
             # Remove everyone with the Birthday role from yesterday
             for member in members:
-                if any(birthday_role == role for role in member.roles):
-                    await client.remove_roles(member, birthday_role)
+                if any(bday_role == role for role in member.roles):
+                    await client.remove_roles(member, bday_role)
 
             # Happy Birthday!
             for birthday_member in all_birthdays[dm_today]:
                 member = server.get_member(birthday_member)
                 if member is not None:
-                    await client.add_roles(member, birthday_role)
+                    await client.add_roles(member, bday_role)
 
         prev = new

--- a/commands/birthday.py
+++ b/commands/birthday.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import defaultdict
 import datetime
 import json
@@ -63,6 +64,7 @@ class Remove(Birthday):
         return "Your birthday has been removed."
 
 
+
 def get_birthdays(bday_file):
     """
     Gets JSON object of all birthdays
@@ -99,3 +101,22 @@ def find_user(birthdays, user):
             return date
 
     return None
+
+
+async def update_birthday():
+    """
+    Update birthdays at the beginning of the day (00:00).
+    """
+    prev = datetime.datetime.today()
+    while True:
+        await asyncio.sleep(5)
+        new = datetime.datetime.today()
+        if new.day != prev.day:
+            # It's a new day - remove all previous roles, add new roles
+            all_birthdays = get_birthdays(BIRTHDAY_FILE)
+            dm_yesterday = prev.strftime("%d/%m")
+            dm_today = new.strftime("%d/%m")
+            for old_birthday in all_birthdays[dm_yesterday]:
+                # get member, remove role, etc
+
+        prev = new

--- a/commands/birthday.py
+++ b/commands/birthday.py
@@ -1,0 +1,101 @@
+from collections import defaultdict
+import datetime
+import json
+import re
+
+from commands.base import Command
+from helpers import CommandFailure
+
+BIRTHDAY_FILE = "files/birthdays.json"
+
+
+class Birthday(Command):
+    desc = "This command can be used to add or remove your birthday. When it is " \
+        "your birthday, PCSocBot will give you the Birthday! role for a day."
+
+
+class Add(Birthday):
+    desc = "Add your own birthday. Please use the format dd/mm " \
+        "(trailing zeroes aren't necessary)."
+
+    def eval(self, birthday):
+        dt_birthday = validate(birthday)
+        if dt_birthday is None:
+            raise CommandFailure("Please input a valid date format (dd/mm).")
+
+        all_birthdays = get_birthdays(BIRTHDAY_FILE)
+
+        # Check if they've already given their birthday
+        curr_date = find_user(all_birthdays, self.user)
+        if curr_date is not None:
+            raise CommandFailure("You've already entered your birthday. "
+                                 "If you wish to change it, please remove it first.")
+
+        # Convert datetime object back to a consistent dd/mm string
+        day_month = dt_birthday.strftime("%d/%m")
+        all_birthdays[day_month].append(self.user)
+
+        with open(BIRTHDAY_FILE, "w") as birthdays:
+            json.dump(all_birthdays, birthdays)
+
+        # TODO: Check if that date is today and if so, get the role?
+        # Could be spammy
+
+        return "Your birthday has been added!"
+
+
+class Remove(Birthday):
+    desc = "Remove your birthday, and don't get the role on your birthday. " \
+        "No arguments are needed."
+
+    def eval(self):
+        all_birthdays = get_birthdays(BIRTHDAY_FILE)
+
+        # Check if they've given their birthday
+        curr_date = find_user(all_birthdays, self.user)
+        if curr_date is None:
+            raise CommandFailure("You haven't supplied your birthday.")
+
+        all_birthdays[curr_date].remove(self.user)
+        with open(BIRTHDAY_FILE, "w") as birthdays:
+            json.dump(all_birthdays, birthdays)
+
+        return "Your birthday has been removed."
+
+
+def get_birthdays(bday_file):
+    """
+    Gets JSON object of all birthdays
+    """
+    all_birthdays = defaultdict(list)
+    try:
+        with open(bday_file) as birthdays:
+            all_birthdays.update(json.load(birthdays))
+    except FileNotFoundError:
+        pass
+
+    return all_birthdays
+
+
+def validate(date_string):
+    """
+    Checks if a given string is a valid date.
+    """
+    try:
+        return datetime.datetime.strptime(date_string, "%d/%m")
+    except ValueError:
+        return None
+
+
+def find_user(birthdays, user):
+    """
+    Finds a user's birthday.
+    Returns the day_month string if their birthday has been stored.
+    Returns None if they haven't inputted their birthday.
+    """
+    # use for ... checking if they've already added and for removing
+    for date, users in birthdays.items():
+        if user in users:
+            return date
+
+    return None

--- a/config/default.ini
+++ b/config/default.ini
@@ -12,6 +12,7 @@ TwitchClientID=
 
 [COMMANDS]
 Archive=on
+Birthday=on
 Crashme=on
 H=on
 Helpme=on


### PR DESCRIPTION
Users can now add their Birthday via PCSocBot to automatically be granted the Birthday! role on their birthday. The role will last until the day is up.

Type `!birthday add <dd/mm>` to add your birthday to the queue, or type `!birthday remove` if you no longer want PCSocBot to track it.