### PR TITLE
Mods can now add/remove birthday roles

### DIFF
--- a/commands/birthday.py
+++ b/commands/birthday.py
@@ -66,8 +66,8 @@ class Remove(Birthday):
 
 
 class ModAdd(Birthday):
-    desc = "Manually grant the Birthday! role to a given user and store their birthday. " \
-        "Mod only."
+    desc = "Manually grant the Birthday! role to a given user and store " \
+        "their birthday. Mod only."
     roles_required = ['mod', 'exec']
 
     async def eval(self, user):
@@ -80,8 +80,9 @@ class ModAdd(Birthday):
         curr_date = find_user(all_birthdays, member.id)
         dm_today = datetime.datetime.today().strftime("%d/%m")
         if curr_date is not None and curr_date != dm_today:
-            raise CommandFailure(f"{bold(user)} already has a birthday set for "
-                                 f"a different date - they don't need the date today")
+            raise CommandFailure(
+                f"{bold(user)} already has a birthday set for "
+                f"a different date - they don't need the date today")
 
         if curr_date is None:
             # User doesn't have any birthday set
@@ -97,7 +98,7 @@ class ModAdd(Birthday):
 
 
 class ModPurge(Birthday):
-    desc = "Remove the Birthday! role from all users in case of bot failure."
+    desc = "Remove the Birthday! role from all users. Mod only."
     roles_required = ['mod', 'exec']
 
     async def eval(self):

--- a/commands/birthday.py
+++ b/commands/birthday.py
@@ -6,7 +6,7 @@ import json
 from discord.utils import find
 
 from commands.base import Command
-from helpers import CommandFailure
+from helpers import CommandFailure, bold
 from configstartup import config
 
 
@@ -38,10 +38,10 @@ class Add(Birthday):
 
         # Convert datetime object back to a consistent dd/mm string
         day_month = dt_birthday.strftime("%d/%m")
-        all_birthdays[day_month].append(self.user)
 
-        with open(BIRTHDAY_FILE, "w") as birthdays:
-            json.dump(all_birthdays, birthdays)
+        # Add it and save
+        all_birthdays[day_month].append(self.user)
+        save_birthdays(all_birthdays)
 
         return f"{dt_birthday:%-d} {dt_birthday:%B} has been added as your birthday!"
 
@@ -58,16 +58,57 @@ class Remove(Birthday):
         if curr_date is None:
             raise CommandFailure("You haven't supplied your birthday.")
 
+        # Remove it and save
         all_birthdays[curr_date].remove(self.user)
-        with open(BIRTHDAY_FILE, "w") as birthdays:
-            json.dump(all_birthdays, birthdays)
+        save_birthdays(all_birthdays)
 
         return "Your birthday has been removed."
 
 
+class ModAdd(Birthday):
+    desc = "Manually grant the Birthday! role to a given user and store their birthday. " \
+        "Mod only."
+    roles_required = ['mod', 'exec']
+
+    async def eval(self, user):
+        member = self.server.get_member_named(user)
+        if member is None:
+            raise CommandFailure(f"User {bold(user)} doesn't exist!")
+
+        # Check if user already has a birthday added
+        all_birthdays = get_birthdays(BIRTHDAY_FILE)
+        curr_date = find_user(all_birthdays, member.id)
+        dm_today = datetime.datetime.today().strftime("%d/%m")
+        if curr_date is not None and curr_date != dm_today:
+            raise CommandFailure(f"{bold(user)} already has a birthday set for "
+                                 f"a different date - they don't need the date today")
+
+        if curr_date is None:
+            # User doesn't have any birthday set
+            # Set their birthday to today for next year
+            all_birthdays[dm_today] = member.id
+            save_birthdays(all_birthdays)
+
+        # Grant them the Birthday! role
+        bday_role = get_role(self.server)
+        await self.client.add_roles(member, bday_role)
+
+        return f"{bold(user)} has been granted the Birthday role."
+
+
+class ModPurge(Birthday):
+    desc = "Remove the Birthday! role from all users in case of bot failure."
+    roles_required = ['mod', 'exec']
+
+    async def eval(self):
+        s = self.server
+        await remove_birthdays(self.client, s.members, get_role(s))
+        return "Removed all Birthday! roles."
+
+
 def get_birthdays(bday_file):
     """
-    Gets JSON object of all birthdays
+    Gets JSON object of all birthdays.
     """
     all_birthdays = defaultdict(list)
     try:
@@ -77,6 +118,14 @@ def get_birthdays(bday_file):
         pass
 
     return all_birthdays
+
+
+def save_birthdays(all_birthdays):
+    """
+    Dump the defaultdict as a JSON file.
+    """
+    with open(BIRTHDAY_FILE, "w") as birthdays:
+        json.dump(all_birthdays, birthdays)
 
 
 def validate(date_string):
@@ -102,6 +151,22 @@ def find_user(birthdays, user):
     return None
 
 
+def get_role(server):
+    """
+    Gets the Birthday! role in the server.
+    """
+    return find(lambda r: r.id == BDAY_ROLE_ID, server.roles)
+
+
+async def remove_birthdays(client, members, bday_role):
+    """
+    Remove Birthday! role from all members in the server.
+    """
+    for member in members:
+        if any(bday_role == role for role in member.roles):
+            await client.remove_roles(member, bday_role)
+
+
 async def update_birthday(client):
     """
     Update birthdays at the beginning of the day (00:00).
@@ -117,13 +182,11 @@ async def update_birthday(client):
 
             # Get all members
             server = list(client.servers)[0]
-            members = server.members
-            bday_role = find(lambda r: r.id == BDAY_ROLE_ID, server.roles)
+            bday_role = get_role(server)
 
             # Remove everyone with the Birthday role from yesterday
-            for member in members:
-                if any(BDAY_ROLE_ID == role.id for role in member.roles):
-                    await client.remove_roles(member, bday_role)
+            # TODO: Generalise this for any role, usable for any command
+            await remove_birthdays(client, server.members, bday_role)
 
             # Happy Birthday!
             for birthday_member in all_birthdays[dm_today]:


### PR DESCRIPTION
- Moderators/Execs can grant the Birthday! role via PCSocBot without asking the server owner to do it manually.
- If the user they want to grant the role to never had a birthday set, then the birthday will be recorded and noted for next year.
- Moderators/Execs can manually purge all users with the Birthday! role in case PCSocBot fails.
- Couple bits of refactoring